### PR TITLE
Fix exceptions not being propagated from `QueryAsync`

### DIFF
--- a/src/NexusMods.Cascade/Topology.cs
+++ b/src/NexusMods.Cascade/Topology.cs
@@ -213,7 +213,7 @@ public sealed class Topology : IDisposable
     public async Task<IQueryResult<T>> QueryAsync<T>(Flow<T> flow) where T : notnull
     {
         var view = new OutletNodeView<T>(this, flow);
-        RunInMainThreadNoWait(() => QueryCore(flow, view));
+        await RunInMainThread(() => QueryCore(flow, view));
         await view.Initialized;
         return view;
     }


### PR DESCRIPTION
Use the async `RunInMainThread` rather than the NoWait version when we can await it, so that we can catch exceptions.

The `RunInMainThreadNoWait` method is quite problematic as it completely swallows any exceptions that happen inside the passed action.

If the action fails due to the exception it can lead to hanging as well, but without the exception being surfaced in any way. 