### PR TITLE
Ensure correct priming of Join operations

### DIFF
--- a/src/NexusMods.Cascade/FlowExtensions.cs
+++ b/src/NexusMods.Cascade/FlowExtensions.cs
@@ -197,7 +197,7 @@ public static class FlowExtensions
                 {
                     foreach (var right in rights[value.Key])
                     {
-                        output.Add(new KeyedValue<TKey, (TLeft, TRight)>(value.Key, (value.Value, right.Key)), delta * right.Value);
+                        output?.Add(new KeyedValue<TKey, (TLeft, TRight)>(value.Key, (value.Value, right.Key)), delta * right.Value);
                     }
                 }
                 lefts.MergeIn(input);
@@ -209,7 +209,7 @@ public static class FlowExtensions
                 {
                     foreach (var left in lefts[value.Key])
                     {
-                        output.Add(new KeyedValue<TKey, (TLeft, TRight)>(value.Key, (left.Key, value.Value)), delta * left.Value);
+                        output?.Add(new KeyedValue<TKey, (TLeft, TRight)>(value.Key, (left.Key, value.Value)), delta * left.Value);
                     }
                 }
                 rights.MergeIn(input);
@@ -263,13 +263,13 @@ public static class FlowExtensions
                     var matchFound = false;
                     foreach (var rightKv in rights[leftKv.Key])
                     {
-                        output.Add((leftKv.Key, (leftKv.Value, rightKv.Key)), delta * rightKv.Value);
+                        output?.Add((leftKv.Key, (leftKv.Value, rightKv.Key)), delta * rightKv.Value);
                         matchFound = true;
                     }
                     if (!matchFound)
                     {
                         // Emit pairing with default(TRight) when no matching right record exists.
-                        output.Add((leftKv.Key, (leftKv.Value, defaultRightValue!)), delta);
+                        output?.Add((leftKv.Key, (leftKv.Value, defaultRightValue!)), delta);
                     }
                 }
                 lefts.MergeIn(input);
@@ -287,10 +287,10 @@ public static class FlowExtensions
                         if (!rights.Contains(rightKv.Key))
                         {
                             // Emit pairing with default(TLeft) when no matching left record exists.
-                            output.Add((rightKv.Key, (leftValue, defaultRightValue!)), -leftDelta);
+                            output?.Add((rightKv.Key, (leftValue, defaultRightValue!)), -leftDelta);
                         }
                         // Note: It is expected that any previous default join output will be canceled by a negative delta.
-                        output.Add((rightKv.Key, (leftValue, rightKv.Value)), delta * leftDelta);
+                        output?.Add((rightKv.Key, (leftValue, rightKv.Value)), delta * leftDelta);
                     }
                 }
                 rights.MergeIn(input);

--- a/src/NexusMods.Cascade/Flows/BinaryFlow.cs
+++ b/src/NexusMods.Cascade/Flows/BinaryFlow.cs
@@ -11,8 +11,8 @@ public class BinaryFlow<TLeft, TRight, TResult, TState> : Flow<TResult>
 {
     public required Func<TState> StateFactory { get; init; }
 
-    public required Action<IToDiffSpan<TLeft>, TState, DiffList<TResult>> StepLeftFn { get; init; }
-    public required Action<IToDiffSpan<TRight>, TState, DiffList<TResult>> StepRightFn { get; init; }
+    public required Action<IToDiffSpan<TLeft>, TState, DiffList<TResult>?> StepLeftFn { get; init; }
+    public required Action<IToDiffSpan<TRight>, TState, DiffList<TResult>?> StepRightFn { get; init; }
     public required Action<TState, DiffList<TResult>> PrimeFn { get; init; }
 
     public override Node CreateNode(Topology topology)
@@ -52,11 +52,13 @@ public class BinaryFlow<TLeft, TRight, TResult, TState> : Flow<TResult>
             var leftCasted = (Node<TLeft>)Upstream[0];
             var rightCasted = (Node<TRight>)Upstream[1];
             Output.Clear();
+
             leftCasted.ResetOutput();
             leftCasted.Prime();
             if (leftCasted.HasOutputData())
             {
-                flow.StepLeftFn(leftCasted.Output, _state, Output);
+                // Update the state without changing the output
+                flow.StepLeftFn(leftCasted.Output, _state, null);
                 leftCasted.ResetOutput();
             }
 
@@ -64,9 +66,12 @@ public class BinaryFlow<TLeft, TRight, TResult, TState> : Flow<TResult>
             rightCasted.Prime();
             if (rightCasted.HasOutputData())
             {
-                flow.StepRightFn(rightCasted.Output, _state, Output);
+                // Update the state without changing the output
+                flow.StepRightFn(rightCasted.Output, _state, null);
                 rightCasted.ResetOutput();
             }
+
+            flow.PrimeFn(_state, Output);
         }
     }
 }


### PR DESCRIPTION
Update binaryFlow priming behaviour to only compute the data after updating both the left and right states, to avoid introducing temporary invalid values in the outputs. This caused issues in complex query hierarchies with multiple leftOuterJoins.

Before running one operation after the other would introduce extra data in the output (default rows and retractions for them) that could lead to other operators down the line not working correctly (outputs are not collapsed until the final outletNode).


This change fixed a query retrieving all enabled LoadoutItemsWithTargetPath in the tests, but it doesn't appear to fix all the issues. Running the same query in the app still resulted in incorrect behaviour. 